### PR TITLE
61 - Strona główna - fix pozycji tytułów sekcji (firefox)

### DIFF
--- a/src/components/homePage/Panel.tsx
+++ b/src/components/homePage/Panel.tsx
@@ -27,7 +27,7 @@ const Panel = ({ children, backgroundStaticImage, ...props }: PanelProps) => {
           "linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent)"
         }
       />
-      <GridItem
+      <Grid
         gridArea="1/1"
         position="relative"
         placeContent="center"
@@ -35,7 +35,7 @@ const Panel = ({ children, backgroundStaticImage, ...props }: PanelProps) => {
         {...props}
       >
         {children}
-      </GridItem>
+      </Grid>
     </Grid>
   );
 };

--- a/src/components/homePage/PanelStack.tsx
+++ b/src/components/homePage/PanelStack.tsx
@@ -14,7 +14,7 @@ const PanelStack = ({ title, children, to }: PanelStackProps) => {
   return (
     <VStack
       p={[1, 4]}
-      gap={[5, 30]}
+      gap={[3, 5, 30]}
       color="white"
       textAlign="center"
       maxWidth="xl"

--- a/src/components/typography/ExtraExtraLargeHeading.tsx
+++ b/src/components/typography/ExtraExtraLargeHeading.tsx
@@ -9,7 +9,7 @@ const ExtraExtraLargeHeading = ({ children, ...props }: HeadingType) => (
     textTransform="uppercase"
     fontFamily="extra-extra-large"
     letterSpacing="wide"
-    size={{ base: "5xl", lg: "7xl" }}
+    size={{ base: "4xl", md: "5xl", lg: "7xl" }}
     {...props}
   >
     {children}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,7 @@ const IndexPage: GatsbyPageWithLayout = () => {
     <Flex as="main" flexDir={{ base: "column", lg: "row" }} height="100vh">
       <Panel
         backgroundStaticImage={HouseStaticImageElement}
-        paddingTop={[15, 0]}
+        marginTop={[20, 0]}
       >
         <PanelStack
           title={t("individual-client")}


### PR DESCRIPTION
poprawiłem pozycjonowanie panelu oraz zauważyłem, że przy niektórych rozdziałkach jeden panel na tablecie zajmował więcej niż 50%